### PR TITLE
QNH tracking

### DIFF
--- a/vSMR/Constant.hpp
+++ b/vSMR/Constant.hpp
@@ -24,6 +24,10 @@ const int TAG_FUNC_DATALINK_VOICE = 547;
 const int TAG_FUNC_DATALINK_RESET = 548;
 const int TAG_FUNC_DATALINK_MESSAGE = 549;
 
+const int TAG_ITEM_QNH = 451;
+const int TAG_FUNC_QNH_UPDATE = 551;
+const int TAG_FUNC_QNH_RESET = 552;
+
 inline static bool startsWith(const char *pre, const char *str) {
   size_t lenpre = strlen(pre), lenstr = strlen(str);
   return lenstr < lenpre ? false : strncmp(pre, str, lenpre) == 0;

--- a/vSMR/QnhTracker.cpp
+++ b/vSMR/QnhTracker.cpp
@@ -1,0 +1,52 @@
+#include "stdafx.h"
+#include <cstring>
+
+#include "QnhTracker.hpp"
+
+void CQnhTracker::processMetar(const char *station, const char *metar)
+{
+	if ((metar = std::strstr(metar, " Q")))
+	{
+		metar += 4;
+
+		auto &entry = aerodrome_qnh[station];
+		if (std::strncmp(entry.qnh, metar, 2))
+		{
+			std::memcpy(entry.qnh, metar, 2);
+			++entry.serial;
+		}
+	}
+	else
+	{
+		aerodrome_qnh.erase(station);
+	}
+}
+
+void CQnhTracker::updateReceivedQnh(const char *callsign, const char *aerodrome)
+{
+	if (auto it = aerodrome_qnh.find(aerodrome); it != aerodrome_qnh.cend())
+		aircraft_qnh[callsign] = it->second;
+}
+
+void CQnhTracker::resetReceivedQnh(const char *callsign)
+{
+	aircraft_qnh.erase(callsign);
+}
+
+CQnhTracker::ReceivedQnh CQnhTracker::getReceivedQnh(const char *callsign, const char *aerodrome, char out[3])
+{
+	if (auto ac = aircraft_qnh.find(callsign); ac != aircraft_qnh.cend())
+	{
+		std::memcpy(out, ac->second.qnh, 2);
+		out[2] = 0;
+
+		if (auto ad = aerodrome_qnh.find(aerodrome); ad != aerodrome_qnh.cend() && ad->second == ac->second)
+			return CQnhTracker::ReceivedQnh::Latest;
+
+		return CQnhTracker::ReceivedQnh::Stale;
+	}
+	else
+	{
+		return CQnhTracker::ReceivedQnh::None;
+	}
+}

--- a/vSMR/QnhTracker.cpp
+++ b/vSMR/QnhTracker.cpp
@@ -5,7 +5,7 @@
 
 void CQnhTracker::processMetar(const char *station, const char *metar)
 {
-	if ((metar = std::strstr(metar, " Q")))
+	if ((metar = std::strstr(metar, " Q")) && std::strlen(metar) >= 6)
 	{
 		metar += 4;
 

--- a/vSMR/QnhTracker.hpp
+++ b/vSMR/QnhTracker.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+class CQnhTracker
+{
+private:
+	struct QnhEntry
+	{
+		char qnh[2];
+		short serial;
+
+		inline bool operator==(const CQnhTracker::QnhEntry &rhs) const {
+			return qnh[0] == rhs.qnh[0] && qnh[1] == rhs.qnh[1] && serial == rhs.serial;
+		}
+	};
+
+	std::map<std::string, QnhEntry> aerodrome_qnh, aircraft_qnh;
+
+public:
+	enum ReceivedQnh
+	{
+		None,
+		Latest,
+		Stale,
+	};
+
+	CQnhTracker() {}
+
+	void processMetar(const char *station, const char *metar);
+
+	void updateReceivedQnh(const char *callsign, const char *aerodrome);
+	void resetReceivedQnh(const char *callsign);
+	ReceivedQnh getReceivedQnh(const char *callsign, const char *aerodrome, char out[3]);
+};

--- a/vSMR/SMRPlugin.cpp
+++ b/vSMR/SMRPlugin.cpp
@@ -311,6 +311,10 @@ CSMRPlugin::CSMRPlugin(void) :CPlugIn(EuroScopePlugIn::COMPATIBILITY_CODE, MY_PL
 	RegisterTagItemType("Datalink clearance", TAG_ITEM_DATALINK_STS);
 	RegisterTagItemFunction("Datalink menu", TAG_FUNC_DATALINK_MENU);
 
+	RegisterTagItemType("Acknowledged QNH", TAG_ITEM_QNH);
+	RegisterTagItemFunction("Update acknowledged QNH", TAG_FUNC_QNH_UPDATE);
+	RegisterTagItemFunction("Reset acknowledged QNH", TAG_FUNC_QNH_RESET);
+
 	messageId = rand() % 10000 + 1789;
 
 	timer = clock();
@@ -412,7 +416,6 @@ bool CSMRPlugin::OnCompileCommand(const char * sCommandLine) {
 }
 
 void CSMRPlugin::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int ItemCode, int TagData, char sItemString[16], int * pColorCode, COLORREF * pRGB, double * pFontSize) {
-
 	if (ItemCode == TAG_ITEM_DATALINK_STS) {
 		if (FlightPlan.IsValid()) {
 			if (std::find(AircraftDemandingClearance.begin(), AircraftDemandingClearance.end(), FlightPlan.GetCallsign()) != AircraftDemandingClearance.end()) {
@@ -453,14 +456,31 @@ void CSMRPlugin::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, 
 			}
 		}
 	}
+
+	if (ItemCode == TAG_ITEM_QNH && FlightPlan.IsValid()) {
+		switch (qnhTracker.getReceivedQnh(FlightPlan.GetCallsign(), FlightPlan.GetFlightPlanData().GetOrigin(), sItemString)) {
+		case CQnhTracker::ReceivedQnh::None:
+			*pColorCode = TAG_COLOR_DEFAULT;
+			strcpy_s(sItemString, 16, "-");
+			break;
+
+		case CQnhTracker::ReceivedQnh::Latest:
+			*pColorCode = TAG_COLOR_REDUNDANT;
+			break;
+
+		case CQnhTracker::ReceivedQnh::Stale:
+			*pColorCode = TAG_COLOR_INFORMATION;
+			break;
+		}
+	}
 }
 
 void CSMRPlugin::OnFunctionCall(int FunctionId, const char * sItemString, POINT Pt, RECT Area)
 {
+	CFlightPlan FlightPlan = FlightPlanSelectASEL();
 
-	if (FunctionId == TAG_FUNC_DATALINK_MENU) {
-		CFlightPlan FlightPlan = FlightPlanSelectASEL();
-
+	switch (FunctionId) {
+	case TAG_FUNC_DATALINK_MENU: {
 		bool menu_is_datalink = true;
 
 		if (FlightPlan.IsValid()) {
@@ -476,11 +496,11 @@ void CSMRPlugin::OnFunctionCall(int FunctionId, const char * sItemString, POINT 
 		AddPopupListElement("Voice", "", TAG_FUNC_DATALINK_VOICE, false, 2, menu_is_datalink);
 		AddPopupListElement("Reset", "", TAG_FUNC_DATALINK_RESET, false, 2, false, true);
 		AddPopupListElement("Close", "", EuroScopePlugIn::TAG_ITEM_FUNCTION_NO, false, 2, false, true);
+
+		break;
 	}
 
-	if (FunctionId == TAG_FUNC_DATALINK_RESET) {
-		CFlightPlan FlightPlan = FlightPlanSelectASEL();
-
+	case TAG_FUNC_DATALINK_RESET:
 		if (FlightPlan.IsValid()) {
 			if (std::find(AircraftDemandingClearance.begin(), AircraftDemandingClearance.end(), FlightPlan.GetCallsign()) != AircraftDemandingClearance.end()) {
 				AircraftDemandingClearance.erase(std::remove(AircraftDemandingClearance.begin(), AircraftDemandingClearance.end(), FlightPlan.GetCallsign()), AircraftDemandingClearance.end());
@@ -501,22 +521,20 @@ void CSMRPlugin::OnFunctionCall(int FunctionId, const char * sItemString, POINT 
 				PendingMessages.erase(FlightPlan.GetCallsign());
 			}
 		}
-	}
 
-	if (FunctionId == TAG_FUNC_DATALINK_STBY) {
-		CFlightPlan FlightPlan = FlightPlanSelectASEL();
+		break;
 
+	case TAG_FUNC_DATALINK_STBY:
 		if (FlightPlan.IsValid()) {
 			AircraftStandby.push_back(FlightPlan.GetCallsign());
 			createPlainCpdlcMessage("STANDBY", "NE");
 			tdest = FlightPlan.GetCallsign();
 			_beginthread(sendDatalinkMessage, 0, NULL);
 		}
-	}
 
-	if (FunctionId == TAG_FUNC_DATALINK_MESSAGE) {
-		CFlightPlan FlightPlan = FlightPlanSelectASEL();
+		break;
 
+	case TAG_FUNC_DATALINK_MESSAGE:
 		if (FlightPlan.IsValid()) {
 			AFX_MANAGE_STATE(AfxGetStaticModuleState());
 
@@ -539,11 +557,10 @@ void CSMRPlugin::OnFunctionCall(int FunctionId, const char * sItemString, POINT 
 			tdest = FlightPlan.GetCallsign();
 			_beginthread(sendDatalinkMessage, 0, NULL);
 		}
-	}
 
-	if (FunctionId == TAG_FUNC_DATALINK_VOICE) {
-		CFlightPlan FlightPlan = FlightPlanSelectASEL();
+		break;
 
+	case TAG_FUNC_DATALINK_VOICE:
 		if (FlightPlan.IsValid()) {
 			createPlainCpdlcMessage("UNABLE - CALL ON FREQ", "R");
 			tdest = FlightPlan.GetCallsign();
@@ -560,11 +577,9 @@ void CSMRPlugin::OnFunctionCall(int FunctionId, const char * sItemString, POINT 
 			_beginthread(sendDatalinkMessage, 0, NULL);
 		}
 
-	}
+		break;
 
-	if (FunctionId == TAG_FUNC_DATALINK_CONFIRM) {
-		CFlightPlan FlightPlan = FlightPlanSelectASEL();
-
+	case TAG_FUNC_DATALINK_CONFIRM:
 		if (FlightPlan.IsValid()) {
 
 			AFX_MANAGE_STATE(AfxGetStaticModuleState());
@@ -629,6 +644,19 @@ void CSMRPlugin::OnFunctionCall(int FunctionId, const char * sItemString, POINT 
 
 		}
 
+		break;
+
+	case TAG_FUNC_QNH_UPDATE:
+		if (FlightPlan.IsValid())
+			qnhTracker.updateReceivedQnh(FlightPlan.GetCallsign(), FlightPlan.GetFlightPlanData().GetOrigin());
+
+		break;
+
+	case TAG_FUNC_QNH_RESET:
+		if (FlightPlan.IsValid())
+			qnhTracker.resetReceivedQnh(FlightPlan.GetCallsign());
+
+		break;
 	}
 }
 
@@ -642,6 +670,8 @@ void CSMRPlugin::OnFlightPlanDisconnect(CFlightPlan FlightPlan)
 
 	if (std::find(ManuallyCorrelated.begin(), ManuallyCorrelated.end(), rt.GetSystemID()) != ManuallyCorrelated.end())
 		ManuallyCorrelated.erase(std::find(ManuallyCorrelated.begin(), ManuallyCorrelated.end(), rt.GetSystemID()));
+
+	qnhTracker.resetReceivedQnh(FlightPlan.GetCallsign());
 }
 
 void CSMRPlugin::OnTimer(int Counter)
@@ -692,6 +722,10 @@ CRadarScreen * CSMRPlugin::OnRadarScreenCreated(const char * sDisplayName, bool 
 	}
 
 	return NULL;
+}
+
+void CSMRPlugin::OnNewMetarReceived(const char *station, const char *metar) {
+	qnhTracker.processMetar(station, metar);
 }
 
 //---EuroScopePlugInExit-----------------------------------------------

--- a/vSMR/SMRPlugin.hpp
+++ b/vSMR/SMRPlugin.hpp
@@ -11,6 +11,7 @@
 #include <thread>
 #include "SMRRadar.hpp"
 #include "Logger.h"
+#include "QnhTracker.hpp"
 
 #define MY_PLUGIN_NAME      "vSMR Vatsim UK"
 #define MY_PLUGIN_VERSION   "dev"
@@ -24,6 +25,9 @@ using namespace EuroScopePlugIn;
 class CSMRPlugin :
 	public EuroScopePlugIn::CPlugIn
 {
+private:
+	CQnhTracker qnhTracker;
+
 public:
 	CSMRPlugin();
 	virtual ~CSMRPlugin();
@@ -51,5 +55,7 @@ public:
 	//---OnRadarScreenCreated------------------------------------------
 
 	virtual CRadarScreen * OnRadarScreenCreated(const char * sDisplayName, bool NeedRadarContent, bool GeoReferenced, bool CanBeSaved, bool CanBeCreated);
+
+	virtual void OnNewMetarReceived(const char *station, const char *metar);
 };
 

--- a/vSMR/vSMR.vcxproj
+++ b/vSMR/vSMR.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="DataLinkDialog.cpp" />
     <ClCompile Include="HttpHelper.cpp" />
     <ClCompile Include="InsetWindow.cpp" />
+    <ClCompile Include="QnhTracker.cpp" />
     <ClCompile Include="Rimcas.cpp" />
     <ClCompile Include="SMRPlugin.cpp" />
     <ClCompile Include="SMRRadar.cpp" />
@@ -164,6 +165,7 @@
     <ClInclude Include="rapidjson\writer.h" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="Rimcas.hpp" />
+    <ClInclude Include="QnhTracker.hpp" />
     <ClInclude Include="SMRPlugin.hpp" />
     <ClInclude Include="SMRRadar.hpp" />
     <ClInclude Include="stdafx.h" />

--- a/vSMR/vSMR.vcxproj.filters
+++ b/vSMR/vSMR.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="AircraftTypeLookup.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="QnhTracker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -126,6 +129,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="AircraftTypeLookup.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="QnhTracker.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Tracks last received QNH per aircraft. Controller can see the last received QNH and whether it is the latest (via new tag item 451), update to the latest QNH (tag function 551), or reset the tracker (552).

On the code: QNH is tracked by a new singleton class which stores each QNH entry as a combination of QNH value, as the two least-significant ASCII digits of the pressure value, and a serial value, to mark a received pressure as stale if the aerodrome QNH changes to a new value, then changes back. The serial will overflow after about a year of continuous half-hourly updates. It probably would be nicer to use a packed representation for the QNH (eg. a `short` containing BCD values) instead of a pair of `char`s, but the `char`s can be copied directly from the METAR and to the tag item string, and the `memcpy` will probably be optimised to a register copy anyway. The QNH is extracted from the METAR on the assumption that the first occurrence of the string ` Q` in the METAR string precedes the QNH, which is true of any valid METAR under Annex 3 (`Q` alone does not suffice because of the `SQ` condition).

Will look to test this at some point when I have time to do so